### PR TITLE
chore: lunchup-backend to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,3 +7,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.112
+- name: lunchup-backend
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.9


### PR DESCRIPTION
chore: Promote lunchup-backend to version 0.0.9