### PR TITLE
chore: jx-python-demo to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.112
+- name: jx-python-demo
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.7
 - name: lunchup-backend
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
chore: Promote jx-python-demo to version 0.0.7